### PR TITLE
Feat. add BE login and logout

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
   plugins: ["prettier"],
   rules: {
     semi: "warn",
+    "no-underscore-dangle": 0,
     "no-unused-vars": "warn",
     "no-param-reassign": 0,
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
   rules: {
     semi: "warn",
     "no-underscore-dangle": 0,
+    "func-names": "off",
     "no-unused-vars": "warn",
     "no-param-reassign": 0,
   },

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .env
 .vscode/*
 .eslintcache
+.eslintignore

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -4,6 +4,7 @@ const CONFIG = {
   PORT: process.env.PORT,
   MONGODB_URL: process.env.MONGODB_URL,
   CLIENT_URL: process.env.CLIENT_URL,
+  SECRET_KEY: process.env.SECRET_KEY,
 };
 
 module.exports = CONFIG;

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -5,6 +5,7 @@ const CONFIG = {
   MONGODB_URL: process.env.MONGODB_URL,
   CLIENT_URL: process.env.CLIENT_URL,
   SECRET_KEY: process.env.SECRET_KEY,
+  ONE_HOUR_IN_MS: 1000 * 60 * 60,
 };
 
 module.exports = CONFIG;

--- a/src/constants/error.js
+++ b/src/constants/error.js
@@ -1,0 +1,24 @@
+const ERROR_PATTERNS = {
+  NOT_AUTHORIZED: {
+    status: 401,
+    message: "Unauthorised",
+    messageForUser: "엑세스 권한이 없습니다 :(",
+  },
+  PAGE_NOT_FOUND: {
+    status: 404,
+    message: "Page Is Not Found",
+    messageForUser: "요청하신 페이지는 존재하지 않습니다 :(",
+  },
+  INTERNAL_SERVER_ERROR: {
+    status: 500,
+    message: "Internal Server Error",
+    messageForUser: "서버오류가 발생하였습니다 :(",
+  },
+  BAD_REQUEST: {
+    status: 400,
+    message: "Bad Request",
+    messageForUser: "잘못된 요청입니다 :(",
+  },
+};
+
+module.exports = ERROR_PATTERNS;

--- a/src/constants/error.js
+++ b/src/constants/error.js
@@ -1,7 +1,7 @@
 const ERROR_PATTERNS = {
   NOT_AUTHORIZED: {
     status: 401,
-    message: "Unauthorised",
+    message: "Unauthorized",
     messageForUser: "엑세스 권한이 없습니다 :(",
   },
   PAGE_NOT_FOUND: {

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -33,3 +33,15 @@ exports.login = async function (req, res, next) {
     next(error);
   }
 };
+
+exports.logOut = async function (req, res, next) {
+  try {
+    res.clearCookie(req.cookies, { httpOnly: true });
+    res.json({ success: true });
+  } catch (error) {
+    error.message = errors.INTERNAL_SERVER_ERROR.message;
+    error.status = errors.INTERNAL_SERVER_ERROR.status;
+
+    next(error);
+  }
+};

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -34,7 +34,7 @@ exports.login = async function (req, res, next) {
   }
 };
 
-exports.logOut = async function (req, res, next) {
+exports.logout = async function (req, res, next) {
   try {
     res.clearCookie(req.cookies, { httpOnly: true });
     res.json({ success: true });

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,6 +1,7 @@
 const User = require("../models/User");
 const jwt = require("../service/jwtUtils");
 const errors = require("../constants/error");
+const CONFIG = require("../constants/config");
 
 exports.login = async function (req, res, next) {
   let member;
@@ -21,8 +22,8 @@ exports.login = async function (req, res, next) {
 
     res
       .status(201)
-      .cookie("accessToken", accessToken, {
-        maxAge: 1000 * 60 * 60,
+      .cookie("AccessToken", accessToken, {
+        maxAge: CONFIG.ONE_HOUR_IN_MS,
         httpOnly: true,
       })
       .json({ success: true, userId: member._id });
@@ -36,7 +37,7 @@ exports.login = async function (req, res, next) {
 
 exports.logout = async function (req, res, next) {
   try {
-    res.clearCookie(req.cookies, { httpOnly: true });
+    res.clearCookie("AccessToken", { httpOnly: true });
     res.json({ success: true });
   } catch (error) {
     error.message = errors.INTERNAL_SERVER_ERROR.message;

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,0 +1,35 @@
+const User = require("../models/User");
+const jwt = require("../service/jwtUtils");
+const errors = require("../constants/error");
+
+exports.login = async function (req, res, next) {
+  let member;
+
+  try {
+    const { email, username } = req.body;
+
+    member = await User.findOne({ email });
+
+    if (!member) {
+      member = await User.create({ email, username });
+    }
+
+    const accessToken = jwt.sign(member);
+    const refreshToken = jwt.refresh();
+
+    await User.findByIdAndUpdate(member._id, { refreshToken });
+
+    res
+      .status(201)
+      .cookie("accessToken", accessToken, {
+        maxAge: 1000 * 60 * 60,
+        httpOnly: true,
+      })
+      .json({ success: true, userId: member._id });
+  } catch (error) {
+    error.message = errors.INTERNAL_SERVER_ERROR.message;
+    error.status = errors.INTERNAL_SERVER_ERROR.status;
+
+    next(error);
+  }
+};

--- a/src/loaders/routers.js
+++ b/src/loaders/routers.js
@@ -1,7 +1,9 @@
 const indexRouter = require("../routes/index");
+const authRouter = require("../routes/auth");
 
 async function routerLoader(app) {
   app.use("/", indexRouter);
+  app.use("/auth", authRouter);
 }
 
 module.exports = routerLoader;

--- a/src/middlewares/verifyToken.js
+++ b/src/middlewares/verifyToken.js
@@ -1,13 +1,14 @@
 const jwt = require("jsonwebtoken");
-const createError = require("http-errors");
 
-const User = require("../models/User");
+const createError = require("http-errors");
 const errors = require("../constants/error");
 const {
   sign,
   accessTokenVerify,
   refreshTokenVerify,
 } = require("../service/jwtUtils");
+
+const User = require("../models/User");
 
 exports.verifyToken = async function (req, res, next) {
   try {

--- a/src/middlewares/verifyToken.js
+++ b/src/middlewares/verifyToken.js
@@ -4,8 +4,8 @@ const createError = require("http-errors");
 const errors = require("../constants/error");
 const {
   sign,
-  accessTokenVerify,
-  refreshTokenVerify,
+  verifyAccessToken,
+  verifyRefreshToken,
 } = require("../service/jwtUtils");
 
 const User = require("../models/User");
@@ -15,12 +15,12 @@ exports.verifyToken = async function (req, res, next) {
     const { accessToken } = req.cookies;
 
     if (accessToken) {
-      const authResult = accessTokenVerify(accessToken);
+      const authResult = verifyAccessToken(accessToken);
       const decodedToken = jwt.decode(accessToken);
 
       const user = await User.findById(decodedToken.id).lean();
 
-      const refreshResult = await refreshTokenVerify(
+      const refreshResult = await verifyRefreshToken(
         user.refreshToken,
         decodedToken.id,
         next,

--- a/src/middlewares/verifyToken.js
+++ b/src/middlewares/verifyToken.js
@@ -1,0 +1,54 @@
+const jwt = require("jsonwebtoken");
+const createError = require("http-errors");
+
+const User = require("../models/User");
+const errors = require("../constants/error");
+const {
+  sign,
+  accessTokenVerify,
+  refreshTokenVerify,
+} = require("../service/jwtUtils");
+
+exports.verifyToken = async function (req, res, next) {
+  try {
+    const { accessToken } = req.cookies;
+
+    if (accessToken) {
+      const authResult = accessTokenVerify(accessToken);
+      const decodedToken = jwt.decode(accessToken);
+
+      const user = await User.findById(decodedToken.id).lean();
+
+      const refreshResult = await refreshTokenVerify(
+        user.refreshToken,
+        decodedToken.id,
+        next,
+      );
+
+      if (!authResult.type && authResult.message === "jwt expired") {
+        if (!refreshResult) {
+          return next(createError(401, errors.NOT_AUTHORIZED.message));
+        }
+
+        const newAccessToken = sign(decodedToken.id);
+
+        res.status(201).cookie("accessToken", newAccessToken, {
+          maxAge: 1000 * 60 * 60,
+          httpOnly: true,
+        });
+
+        return next();
+      }
+
+      req.user = decodedToken.id;
+      return next();
+    }
+
+    return next(createError(401, errors.NOT_AUTHORIZED.message));
+  } catch (error) {
+    error.message = errors.NOT_AUTHORIZED.message;
+    error.status = errors.NOT_AUTHORIZED.status;
+
+    return next(error);
+  }
+};

--- a/src/middlewares/verifyToken.js
+++ b/src/middlewares/verifyToken.js
@@ -9,6 +9,7 @@ const {
 } = require("../service/jwtUtils");
 
 const User = require("../models/User");
+const CONFIG = require("../constants/config");
 
 exports.verifyToken = async function (req, res, next) {
   try {
@@ -34,7 +35,7 @@ exports.verifyToken = async function (req, res, next) {
         const newAccessToken = sign(decodedToken.id);
 
         res.status(201).cookie("accessToken", newAccessToken, {
-          maxAge: 1000 * 60 * 60,
+          maxAge: CONFIG.ONE_HOUR_IN_MS,
           httpOnly: true,
         });
 

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -5,6 +5,6 @@ const authController = require("../controllers/auth.controller");
 const router = express.Router();
 
 router.post("/login", authController.login);
-router.post("/logout", authController.logOut);
+router.post("/logout", authController.logout);
 
 module.exports = router;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,0 +1,10 @@
+const express = require("express");
+
+const authController = require("../controllers/auth.controller");
+
+const router = express.Router();
+
+router.post("/login", authController.login);
+router.post("/logout", authController.logOut);
+
+module.exports = router;

--- a/src/service/jwtUtils.js
+++ b/src/service/jwtUtils.js
@@ -7,3 +7,9 @@ exports.sign = function (user) {
     expiresIn: "1h",
   });
 };
+
+exports.refresh = function () {
+  return jwt.sign({}, CONFIG.SECRET_KEY, {
+    expiresIn: "14d",
+  });
+};

--- a/src/service/jwtUtils.js
+++ b/src/service/jwtUtils.js
@@ -1,0 +1,9 @@
+const jwt = require("jsonwebtoken");
+
+const CONFIG = require("../constants/config");
+
+exports.sign = function (user) {
+  return jwt.sign({ id: user._id }, CONFIG.SECRETKEY, {
+    expiresIn: "1h",
+  });
+};

--- a/src/service/jwtUtils.js
+++ b/src/service/jwtUtils.js
@@ -18,6 +18,7 @@ exports.refresh = function () {
 exports.accessTokenVerify = function (token) {
   try {
     const user = jwt.verify(token, CONFIG.SECRET_KEY);
+
     return {
       type: true,
       id: user.id,
@@ -33,14 +34,17 @@ exports.accessTokenVerify = function (token) {
 exports.refreshTokenVerify = async function (token, id, next) {
   try {
     const user = await User.findById(id);
+
     if (token === user.refreshToken) {
       try {
         jwt.verify(token, CONFIG.SECRET_KEY);
+
         return true;
       } catch (error) {
         return false;
       }
     }
+
     return false;
   } catch (error) {
     error.message = errors.INTERNAL_SERVER_ERROR.message;

--- a/src/service/jwtUtils.js
+++ b/src/service/jwtUtils.js
@@ -15,7 +15,7 @@ exports.refresh = function () {
   });
 };
 
-exports.accessTokenVerify = function (token) {
+exports.verifyAccessToken = function (token) {
   try {
     const user = jwt.verify(token, CONFIG.SECRET_KEY);
 
@@ -31,7 +31,7 @@ exports.accessTokenVerify = function (token) {
   }
 };
 
-exports.refreshTokenVerify = async function (token, id, next) {
+exports.verifyRefreshToken = async function (token, id, next) {
   try {
     const user = await User.findById(id);
 

--- a/src/service/jwtUtils.js
+++ b/src/service/jwtUtils.js
@@ -4,7 +4,7 @@ const errors = require("../constants/error");
 const CONFIG = require("../constants/config");
 
 exports.sign = function (user) {
-  return jwt.sign({ id: user._id }, CONFIG.SECRETKEY, {
+  return jwt.sign({ id: user._id }, CONFIG.SECRET_KEY, {
     expiresIn: "1h",
   });
 };

--- a/src/service/jwtUtils.js
+++ b/src/service/jwtUtils.js
@@ -1,5 +1,6 @@
 const jwt = require("jsonwebtoken");
-
+const User = require("../models/User");
+const errors = require("../constants/error");
 const CONFIG = require("../constants/config");
 
 exports.sign = function (user) {
@@ -12,4 +13,41 @@ exports.refresh = function () {
   return jwt.sign({}, CONFIG.SECRET_KEY, {
     expiresIn: "14d",
   });
+};
+
+exports.accessTokenVerify = function (token) {
+  try {
+    const user = jwt.verify(token, CONFIG.SECRET_KEY);
+    return {
+      type: true,
+      id: user.id,
+    };
+  } catch (error) {
+    return {
+      type: false,
+      message: error.message,
+    };
+  }
+};
+
+exports.refreshTokenVerify = async function (token, id, next) {
+  try {
+    const user = await User.findById(id);
+    if (token === user.refreshToken) {
+      try {
+        jwt.verify(token, CONFIG.SECRET_KEY);
+        return true;
+      } catch (error) {
+        return false;
+      }
+    }
+    return false;
+  } catch (error) {
+    error.message = errors.INTERNAL_SERVER_ERROR.message;
+    error.status = errors.INTERNAL_SERVER_ERROR.status;
+
+    next(error);
+  }
+
+  return null;
 };


### PR DESCRIPTION
### [노션 칸반 - 로그인 응답](https://poised-moon-73b.notion.site/BE-7c15869e0d724f34ba31bfea11f38192?pvs=4)
### [노션 칸반 - 로그아웃 응답](https://poised-moon-73b.notion.site/BE-1ce00c5525da4b709742121b8ef3e377?pvs=4)

### description

BE 로그인과 로그아웃 응답 및 토큰을 검정하는 미들웨어를 구현 하였습니다. 
1. 라우터 설정 및 엔드포인트 설정
2. 클라이언트에서 받아온 로그인 유저 정보를 기반으로 
 - 이미 DB에 있는 유저라면 그대로 해당 정보를 토큰화 하여 access토큰과 refreh 토큰 생성하여
 - access 토큰은 쿠키에 담아 클라이언트에 전달
 - refresh 토큰은 해당 DB에서 해당 user에게 저장
3. 미들웨어에서 토큰 유무 및 만료 검사 후 다음 미들웨어로 넘김
4. 로그아웃 시에 `clear cookie`를 통해 저장된 토큰을 삭제

### concern

error scenario 관련 더욱 자세한 정보를 통해 클라이언트에서 렌더링 해주는 방식으로 하기 위해 error scenario 및 error 핸들러를 수정 하면 좋을듯 한데 이 부분에 관해 고민이 있습니다!! 

1. 현재 시점 및 현재 브랜치(로그인) 에서 하는게 올바른지?
2. BE 에러 핸들링을 담당하는 해당 태스크때 수정하는게 좋을지?
3. 현재 시점 다른 브랜치를 파서 하는게 좋을지? 

여러분의 의견이 궁금합니다!

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.

### 스크린샷 
다음과 같이 클라이언트의 네트워크 탭에서 확인이 가능합니다!! 

#### 로그인시
<img width="620" alt="스크린샷 2023-07-22 오후 5 52 46" src="https://github.com/Team-Dataface/DataFace-server/assets/111283378/e3285697-46dd-4ba3-bd7d-3f78acd6bcd2">

#### 로그아웃시
<img width="620" alt="스크린샷 2023-07-22 오후 5 53 10" src="https://github.com/Team-Dataface/DataFace-server/assets/111283378/8415c729-b1eb-443d-b50e-7e07a0388a00">
