### PR TITLE
Feat. add getAllDatabases controller function

### DIFF
--- a/src/controllers/database.controller.js
+++ b/src/controllers/database.controller.js
@@ -1,0 +1,25 @@
+/* eslint-disable consistent-return */
+const User = require("../models/User");
+const Database = require("../models/Database");
+
+exports.getAllDatabases = async function (req, res, next) {
+  const userId = req.params.userid;
+
+  try {
+    const user = await User.findById(userId);
+
+    if (!user) {
+      return res.status(404).json({ error: "User Not Found" });
+    }
+
+    const databases = await Database.find({ createdBy: user })
+      .populate("createdBy")
+      .populate("documents")
+      .exec();
+
+    res.status(200).json({ databases });
+  } catch (err) {
+    console.error("Error while fetching databases", err);
+    res.status(500).json({ error: "Failed to retrieve databases" });
+  }
+};

--- a/src/controllers/database.controller.js
+++ b/src/controllers/database.controller.js
@@ -1,4 +1,6 @@
 /* eslint-disable consistent-return */
+const mongoose = require("mongoose");
+
 const User = require("../models/User");
 const Database = require("../models/Database");
 
@@ -12,7 +14,9 @@ exports.getAllDatabases = async function (req, res, next) {
       return res.status(404).json({ error: "User Not Found" });
     }
 
-    const databases = await Database.find({ createdBy: user })
+    const databases = await Database.find({
+      "createdBy._id": new mongoose.Types.ObjectId(userId),
+    })
       .populate("createdBy")
       .populate("documents")
       .exec();

--- a/src/loaders/routers.js
+++ b/src/loaders/routers.js
@@ -1,9 +1,11 @@
 const indexRouter = require("../routes/index");
 const authRouter = require("../routes/auth");
+const userRouter = require("../routes/users");
 
 async function routerLoader(app) {
   app.use("/", indexRouter);
   app.use("/auth", authRouter);
+  app.use("/users", userRouter);
 }
 
 module.exports = routerLoader;

--- a/src/models/Database.js
+++ b/src/models/Database.js
@@ -5,10 +5,16 @@ const databaseSchema = new mongoose.Schema({
     type: String,
     required: [true, "Database name is required"],
   },
-  documents: {
+  createdBy: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: "Document",
+    ref: "User",
   },
+  documents: [
+    {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Document",
+    },
+  ],
 });
 
 module.exports = mongoose.model("Database", databaseSchema);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -10,10 +10,12 @@ const userSchema = new mongoose.Schema({
     type: String,
     required: [true, "Email is required"],
   },
-  databases: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: "Database",
-  },
+  databases: [
+    {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Database",
+    },
+  ],
   refreshToken: {
     type: String,
   },

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,0 +1,9 @@
+const express = require("express");
+
+const databaseController = require("../controllers/database.controller");
+
+const router = express.Router();
+
+router.get("/:userid/databases", databaseController.getAllDatabases);
+
+module.exports = router;


### PR DESCRIPTION
### [[BE] 노션 칸반 - 전체 Database 목록 응답](https://www.notion.so/BE-Database-6d0ff3701bae4b72bc52a78b264a8521?pvs=4)

### description
- **[주요사항] 현재 접속한 유저가 생성한 모든 Database 목록을 조회하여 응답하는 `getAllDatabases` 컨트롤러 함수 작성**
- 스키마 간 상호참조가 가능하도록 `userSchema`와 `databaseSchema`의 속성 수정
- `userRouter`와 `databaseController` 셋업

### concern
- 아직 생성된 실제 Database가 없고, 스키마 간 상호참조로 인해 Mock Data를 활용한 컨트롤러 함수 테스트가 제한적인 상황입니다. 금일 프론트엔드와 요청-응답 연결하여 테스트 해 볼 예정입니다.
- 만약 에러가 발생한다면, `populate` Mongoose 메소드의 활용이 잘못되었을 가능성이 있습니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.