### PR TITLE
Hotfix. respond document id to client when newly created

### DIFF
--- a/src/controllers/document.controller.js
+++ b/src/controllers/document.controller.js
@@ -59,7 +59,7 @@ exports.createDocument = async function (req, res, next) {
 
     await user.save();
 
-    res.status(201).json({ success: true });
+    res.status(201).json({ success: true, newDocument });
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: "Failed to create document" });


### PR DESCRIPTION
### description

- list view는 항상 all document list를 받지만 detail view는 단일 document만을 요청하기에 detail view 상에서 +를 눌러 새 document를 생성할 경우 id를 알 길이 없어 에러가 일어납니다.

서버에서 생성을 성공적으로 마쳤을 경우 response에 id를 함께 담아 보내주도록 fix하였습니다.

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.
