### PR TITLE
Feat. set coordinates of every documents upon edit request

### DIFF
--- a/src/controllers/database.controller.js
+++ b/src/controllers/database.controller.js
@@ -31,10 +31,14 @@ exports.createDatabase = async function (req, res, next) {
       return res.status(404).json({ error: "User Not Found" });
     }
 
-    const fieldsArray = fields.map(({ fieldName, fieldType }) => ({
-      fieldName,
-      fieldType,
-    }));
+    const fieldsArray = fields.map(
+      ({ fieldName, fieldType, fieldValue }, index) => ({
+        fieldName,
+        fieldType,
+        fieldValue,
+        yCoordinate: index * 40,
+      }),
+    );
 
     const newDatabase = await user.databases.create({
       name: dbName,

--- a/src/controllers/document.controller.js
+++ b/src/controllers/document.controller.js
@@ -167,15 +167,25 @@ exports.editDocument = async function (req, res, next) {
       return res.status(404).json({ error: "Document Not Found" });
     }
 
-    fields.forEach(({ fieldId, fieldValue }) => {
-      const field = document.fields.id(fieldId);
+    fields.forEach(
+      ({ fieldId, fieldValue, fieldName, xCoordinate, yCoordinate }) => {
+        const field = document.fields.id(fieldId);
 
-      if (!field) {
-        return res.status(404).json({ error: "Field Not Found" });
-      }
+        if (!field) {
+          return res.status(404).json({ error: "Field Not Found" });
+        }
 
-      field.fieldValue = fieldValue;
-    });
+        field.fieldValue = fieldValue;
+        database.documents.forEach((doc) => {
+          const targetField = doc.fields.find(
+            (fld) => fld.fieldName === fieldName,
+          );
+
+          targetField.xCoordinate = xCoordinate;
+          targetField.yCoordinate = yCoordinate;
+        });
+      },
+    );
 
     await user.save();
 


### PR DESCRIPTION
### [노션 칸반 - [BE]Detail - edit mode 수정 응답](https://www.notion.so/BE-Document-Detail-View-2c01688afd064729a625cead9145ee87?pvs=4)

### description

- 데이터베이스 생성시 xCoordinates(초기값: 0) 와 yCoordinates (초기값: 0부터 출발하여 40배수) 설정.

초기 y값을 40배수로 미리 설정해줌으로써 클라이언트에서 load시 위아래로 나열된 형태가 됩니다.

- 한 document의 xCoordinates와 yCoordinates 변경 요청이 들어올 경우,
모든 documents에 대하여 일괄적용해야하므로 관련 로직을 구현하였습니다.

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.

### 스크린샷

![Jul-29-2023 04-12-52](https://github.com/Team-Dataface/DataFace-server/assets/83858724/bf3cf4e5-9618-4edf-af73-7621f079d3d9)


