### PR TITLE
Hotfix. change default fieldValue value to whitespace

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -58,7 +58,7 @@ const userSchema = new Schema({
 documentSchema.pre("validate", function (next) {
   this.fields = this.fields.map((field) => ({
     ...field,
-    fieldValue: field.fieldValue || "default",
+    fieldValue: field.fieldValue || " ",
   }));
   next();
 });


### PR DESCRIPTION
### [[BE] Database 생성 응답](https://www.notion.so/BE-Database-b0927a2cc9a94b828f84a45561c94427?pvs=4)

### description
- **처음 Database가 생성될 때 생성되는 Document의 default fieldValue를 `"default"` string에서 빈 string으로 변경**

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.