### PR TITLE
Hotfix. add coordinate value inputs for createDocument function

### DIFF
--- a/src/controllers/document.controller.js
+++ b/src/controllers/document.controller.js
@@ -45,11 +45,15 @@ exports.createDocument = async function (req, res, next) {
       return res.status(404).json({ error: "Database Not Found" });
     }
 
-    const fieldsArray = fields.map(({ fieldName, fieldType, fieldValue }) => ({
-      fieldName,
-      fieldType,
-      fieldValue,
-    }));
+    const fieldsArray = fields.map(
+      ({ fieldName, fieldType, fieldValue, xCoordinate, yCoordinate }) => ({
+        fieldName,
+        fieldType,
+        fieldValue,
+        xCoordinate,
+        yCoordinate,
+      }),
+    );
 
     const newDocument = await database.documents.create({
       fields: fieldsArray,


### PR DESCRIPTION
### [[BE] Document 생성 응답](https://www.notion.so/BE-Document-1444c197e7f74e1580543c43d2c843ae?pvs=4)

### description
- document의 field 위치들이 GUI에서 변경된 후, 동일한 database에서 새로운 document를 생성할 때 document의 스키마 초기값인 (0, 0)으로 x, y좌표 값이 설정되는 문제를 해결
  - 클라이언트에서 document 생성 요청을 보낼 때 `xCoordinate`와 `yCoordinate` 값을 추가로 보내줘야 함

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.