### PR TITLE
Feat. add getRelatedFields controller function

### DIFF
--- a/src/controllers/relationship.controller.js
+++ b/src/controllers/relationship.controller.js
@@ -72,18 +72,11 @@ exports.getRelatedFields = async function (req, res, next) {
       return !!relatedFields.length;
     });
 
-    const displayedDocuments = [];
-
-    relatedDocuments.forEach((document) => {
-      const displayedFields = [];
-
-      document.fields.forEach((field) => {
-        if (foreignFieldsToDisplay.includes(field.fieldName)) {
-          displayedFields.push(field);
-        }
-      });
-
-      displayedDocuments.push({ fields: displayedFields });
+    const displayedDocuments = relatedDocuments.map((document) => {
+      const displayedFields = document.fields.filter((field) =>
+        foreignFieldsToDisplay.includes(field.fieldName),
+      );
+      return { fields: displayedFields };
     });
 
     res.json({ displayedDocuments });

--- a/src/controllers/relationship.controller.js
+++ b/src/controllers/relationship.controller.js
@@ -31,3 +31,65 @@ exports.createRelationship = async function (req, res, next) {
     res.status(500).json({ error: "Failed to create database relationship" });
   }
 };
+
+// /:userid/databases/:databaseid/relationships/:relationshipid?primaryFieldValue=_____
+exports.getRelatedFields = async function (req, res, next) {
+  const userId = req.params.userid;
+  const databaseId = req.params.databaseid;
+  const relationshipId = req.params.relationshipid;
+  const { primaryFieldValue } = req.query;
+
+  try {
+    const user = await User.findById(userId);
+
+    if (!user) {
+      return res.status(404).json({ error: "User Not Found" });
+    }
+
+    const database = user.databases.id(databaseId);
+
+    if (!database) {
+      return res.status(404).json({ error: "Database Not Found" });
+    }
+
+    const relationship = database.relationships.id(relationshipId);
+
+    if (!relationship) {
+      return res.status(404).json({ error: "Relationship Not Found" });
+    }
+
+    const { foreignDbId, foreignFieldName, foreignFieldsToDisplay } =
+      relationship;
+
+    const foreignDatabase = user.databases.id(foreignDbId);
+
+    const relatedDocuments = foreignDatabase.documents.filter((document) => {
+      const relatedFields = document.fields.filter(
+        (field) =>
+          field.fieldName === foreignFieldName &&
+          field.fieldValue === primaryFieldValue,
+      );
+
+      return !!relatedFields.length;
+    });
+
+    const displayedDocuments = [];
+
+    relatedDocuments.forEach((document) => {
+      const displayedFields = [];
+
+      document.fields.forEach((field) => {
+        if (foreignFieldsToDisplay.includes(field.fieldName)) {
+          displayedFields.push(field);
+        }
+      });
+
+      displayedDocuments.push({ fields: displayedFields });
+    });
+
+    res.json({ displayedDocuments });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Failed to get related fields" });
+  }
+};

--- a/src/controllers/relationship.controller.js
+++ b/src/controllers/relationship.controller.js
@@ -32,7 +32,6 @@ exports.createRelationship = async function (req, res, next) {
   }
 };
 
-// /:userid/databases/:databaseid/relationships/:relationshipid?primaryFieldValue=_____
 exports.getRelatedFields = async function (req, res, next) {
   const userId = req.params.userid;
   const databaseId = req.params.databaseid;

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -4,19 +4,19 @@ const { Schema } = mongoose;
 
 const relationshipSchema = new Schema([
   {
-    primaryFieldId: {
-      type: Schema.Types.ObjectId,
+    primaryFieldName: {
+      type: String,
       required: true,
     },
     foreignDbId: {
       type: Schema.Types.ObjectId,
       required: true,
     },
-    foreignFieldId: {
-      type: Schema.Types.ObjectId,
+    foreignFieldName: {
+      type: String,
       required: true,
     },
-    fieldsToDisplay: {
+    foreignFieldsToDisplay: {
       type: Array,
       default: [],
       required: true,
@@ -30,6 +30,11 @@ const relationshipSchema = new Schema([
       type: Number,
       required: true,
       default: 0,
+    },
+    portalSize: {
+      type: Number,
+      required: true,
+      default: 150,
     },
   },
 ]);

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -45,5 +45,9 @@ router.post(
   "/:userid/databases/:databaseid/relationships",
   relationshipController.createRelationship,
 );
+router.get(
+  "/:userid/databases/:databaseid/relationships/:relationshipid",
+  relationshipController.getRelatedFields,
+);
 
 module.exports = router;


### PR DESCRIPTION
### [BE] Portal - 관계 설정된 Database로의 조건부 쿼리 응답

### description
- **관계 설정된 Database에서 사용자가 요청한 document + field 조합만 조회해서 받아오는 `getRelatedFields` 컨트롤러 함수 작성**

  - mongoDB는 collection 간의 관계 설정을 별도로 지원하지 않지만, 관계형 데이터베이스의 `Primary Key`, `Foreign Key`를 사용한 관계 설정에 착안하여, **사용자가 직접 Primary Key, Foreign Key를 설정할 수 있게 함**
  
  - 설정된 Primary Key, Foreign Key를 활용하여 관계 설정된 `foreignDatabase`를 특정할 수 있도록 하고, Primary Key의 특정 value를 통해 `foreignDatabase`에서 원하는 데이터만 선택적으로 요청 받아올 수 있도록 함
    - `GET` HTTP 요청에서 클라이언트가 송신하는 동적인 값을 서버에서 활용하기 위해, **Query String**을 도입하여 사용함

- **getRelatedFields 클라이언트 요청 Endpoint** (Query String 활용)
  - `/users/:userid/databases/:databaseid/relationships/:relationshipid?primaryFieldValue={primaryFieldValue}`

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.