### PR TITLE
Feat. add put router for relation to save portal design properties

### DIFF
--- a/src/controllers/relationship.controller.js
+++ b/src/controllers/relationship.controller.js
@@ -66,6 +66,39 @@ exports.createRelationship = async function (req, res, next) {
   }
 };
 
+exports.editRelationship = async function (req, res, next) {
+  const userId = req.params.userid;
+  const databaseId = req.params.databaseid;
+  const editedRelationship = req.body;
+
+  try {
+    const user = await User.findById(userId);
+
+    if (!user) {
+      return res.status(404).json({ error: "User Not Found" });
+    }
+
+    const database = user.databases.id(databaseId);
+
+    if (!database) {
+      return res.status(404).json({ error: "Database Not Found" });
+    }
+
+    const { relationships } = database;
+
+    relationships[0].xCoordinate = editedRelationship.xCoordinate;
+    relationships[0].yCoordinate = editedRelationship.yCoordinate;
+    relationships[0].portalSize = editedRelationship.portalSize;
+
+    await user.save();
+
+    res.status(200).json({ success: true });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Failed to edit document" });
+  }
+};
+
 exports.getRelatedFields = async function (req, res, next) {
   const userId = req.params.userid;
   const databaseId = req.params.databaseid;

--- a/src/controllers/relationship.controller.js
+++ b/src/controllers/relationship.controller.js
@@ -69,7 +69,7 @@ exports.createRelationship = async function (req, res, next) {
 exports.editRelationship = async function (req, res, next) {
   const userId = req.params.userid;
   const databaseId = req.params.databaseid;
-  const editedRelationship = req.body;
+  const editedRelationships = req.body;
 
   try {
     const user = await User.findById(userId);
@@ -86,16 +86,18 @@ exports.editRelationship = async function (req, res, next) {
 
     const { relationships } = database;
 
-    relationships[0].xCoordinate = editedRelationship.xCoordinate;
-    relationships[0].yCoordinate = editedRelationship.yCoordinate;
-    relationships[0].portalSize = editedRelationship.portalSize;
+    relationships.forEach((element, index) => {
+      element.xCoordinate = editedRelationships[index].xCoordinate;
+      element.yCoordinate = editedRelationships[index].yCoordinate;
+      element.portalSize = editedRelationships[index].portalSize;
+    });
 
     await user.save();
 
     res.status(200).json({ success: true });
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: "Failed to edit document" });
+    res.status(500).json({ error: "Failed to edit relationship" });
   }
 };
 

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -49,6 +49,10 @@ router.post(
   "/:userid/databases/:databaseid/relationships",
   relationshipController.createRelationship,
 );
+router.put(
+  "/:userid/databases/:databaseid/relationships",
+  relationshipController.editRelationship,
+);
 
 router.get(
   "/:userid/databases/:databaseid/relationships/:relationshipid",


### PR DESCRIPTION
### [노션 칸반 - Portal](https://www.notion.so/FE-Detail-view-Portal-699c8d931850428b83d0cd5e75b8d20a?pvs=4)

### description

- portal의 xCoordinate, yCoordinate, portalSize 프로퍼티를 수정하여 DB에 저장할 수 있도록 put endpoint를 작성했습니다.

### remarks

- 백엔드의 전체적 통일성과 어긋나는 내용이 있다면 말씀해주세요. 수정하겠습니다.

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.

### 스크린샷

![Aug-01-2023 16-02-10](https://github.com/Team-Dataface/DataFace-server/assets/83858724/44e8f57a-18fa-4539-b947-87881ccc113e)

