### PR TITLE
Hotfix. delete index router

### DIFF
--- a/src/loaders/routers.js
+++ b/src/loaders/routers.js
@@ -1,9 +1,7 @@
-const indexRouter = require("../routes/index");
 const authRouter = require("../routes/auth");
 const userRouter = require("../routes/users");
 
 async function routerLoader(app) {
-  app.use("/", indexRouter);
   app.use("/auth", authRouter);
   app.use("/users", userRouter);
 }


### PR DESCRIPTION
### description

- `/` 엔드포인트를 참조하고 있는 `indexRouter`을 삭제했습니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.