### PR TITLE
Feat. insert date of creation into the value if the type is 'Date created'

### DIFF
--- a/src/controllers/database.controller.js
+++ b/src/controllers/database.controller.js
@@ -1,5 +1,6 @@
 /* eslint-disable consistent-return */
 const User = require("../models/User");
+const { getTodaysDate } = require("../utils/getTodaysDate");
 
 exports.getAllDatabases = async function (req, res, next) {
   const userId = req.params.userid;
@@ -31,14 +32,23 @@ exports.createDatabase = async function (req, res, next) {
       return res.status(404).json({ error: "User Not Found" });
     }
 
-    const fieldsArray = fields.map(
-      ({ fieldName, fieldType, fieldValue }, index) => ({
-        fieldName,
-        fieldType,
-        fieldValue,
+    const fieldsArray = fields.map((field, index) => {
+      if (
+        field.fieldType === "Date created" ||
+        field.fieldType === "Date modified"
+      ) {
+        return {
+          ...field,
+          fieldValue: getTodaysDate(),
+          yCoordinate: index * 40,
+        };
+      }
+
+      return {
+        ...field,
         yCoordinate: index * 40,
-      }),
-    );
+      };
+    });
 
     const newDatabase = await user.databases.create({
       name: DBName,

--- a/src/controllers/document.controller.js
+++ b/src/controllers/document.controller.js
@@ -1,5 +1,6 @@
 /* eslint-disable consistent-return */
 const User = require("../models/User");
+const { getTodaysDate } = require("../utils/getTodaysDate");
 
 exports.getAllDocuments = async function (req, res, next) {
   const userId = req.params.userid;
@@ -45,23 +46,18 @@ exports.createDocument = async function (req, res, next) {
       return res.status(404).json({ error: "Database Not Found" });
     }
 
-    const fieldsArray = fields.map(
-      ({
-        fieldName,
-        fieldType,
-        fieldValue,
-        xCoordinate,
-        yCoordinate,
-        rows,
-      }) => ({
-        fieldName,
-        fieldType,
-        fieldValue,
-        xCoordinate,
-        yCoordinate,
-        rows,
-      }),
-    );
+    const fieldsArray = fields.map((field) => {
+      if (field.fieldType === "Date created") {
+        return {
+          ...field,
+          fieldValue: getTodaysDate(),
+        };
+      }
+
+      return {
+        ...field,
+      };
+    });
 
     const newDocument = await database.documents.create({
       fields: fieldsArray,

--- a/src/utils/getTodaysDate.js
+++ b/src/utils/getTodaysDate.js
@@ -1,0 +1,8 @@
+exports.getTodaysDate = () => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  const day = String(today.getDate()).padStart(2, "0");
+
+  return `${year}/${month}/${day}`;
+};


### PR DESCRIPTION
### description

- Type에 따른 조건부로 스키마의 type이나 validation등을 동적으로 수정할 수는 없기에
오늘 날짜 "string"을 넣어주는 방식으로 Date created 기능을 구현하였습니다.
포맷은 클라이언트와 동일하게 YYYY/MM/DD이며 해당기능을 위한 util 함수를 별도로 추가했습니다.

- 새 DB를 추가할 때, 타입이 Date created || Date modified 인 경우, 오늘 날짜가 Value에 삽입됩니다.
- 새 Doc을 추가할 때 타입이 Date created 마찬가지로 오늘 날짜가 value에 삽입됩니다.

- 이전에 토의했던 대로 타입이 Date modified인 경우, 백엔드에서 최신 date string을 value에 덮어써주어야 하나, 현재 listview모드에서 취합해 전송하는 req.body 데이터 내부에 fieldType이 없는 관계로 바로 구현이 어렵습니다. 나중에 프론트백을 함께 수정하는 기회를 가지려 합니다. 조만간 이어 진행하도록 하겠습니다. 

현시점 기능상 큰 문제는 없으나 다음 상황에서 원치않은 결과를 보여줄 수 있습니다.
예시) 유저가 1월 1일 11시 50분 경까지 수정을 하다가 15분간 휴식을 취하고 돌아와 1월 2일 0시 5분에 fetch를 했을 경우 2023/01/01이 적용됨.

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.

### 스크린샷

![created](https://github.com/Team-Dataface/DataFace-server/assets/83858724/a698f473-e7e5-4f85-9dce-adef62571c4c)

